### PR TITLE
feat(relations): allow to hide or rename pivot attribute on belongsTo…

### DIFF
--- a/src/Lucid/Relations/BelongsToMany.js
+++ b/src/Lucid/Relations/BelongsToMany.js
@@ -168,14 +168,12 @@ class BelongsToMany extends BaseRelation {
     let pivotAttribute = this._pivot.pivotAttribute
 
     if (this._PivotModel && !_.isUndefined(this._PivotModel.pivotAttribute)) {
-      const attribute = this._PivotModel.pivotAttribute
+      pivotAttribute = this._PivotModel.pivotAttribute
+    }
 
-      // Is `true`. set default value `pivot`.
-      if (attribute === true) {
-        pivotAttribute = 'pivot'
-      } else {
-        pivotAttribute = attribute
-      }
+    // Is `true`. set default value `pivot`.
+    if (pivotAttribute === true) {
+      pivotAttribute = 'pivot'
     }
 
     return pivotAttribute

--- a/src/Lucid/Relations/BelongsToMany.js
+++ b/src/Lucid/Relations/BelongsToMany.js
@@ -383,10 +383,6 @@ class BelongsToMany extends BaseRelation {
      */
     let hidden = _.get(pivotModel, '$hidden', [])
 
-    if (hidden.length === 0 && _.hasIn(pivotModel, 'constructor.hidden')) {
-      hidden = pivotModel.constructor.hidden
-    }
-
     return (
       (_.isArray(hidden) && hidden.includes('$pivot') === true) ||
       this.$pivotAttribute === false

--- a/src/Lucid/Relations/BelongsToMany.js
+++ b/src/Lucid/Relations/BelongsToMany.js
@@ -354,7 +354,7 @@ class BelongsToMany extends BaseRelation {
      *
      * @link https://github.com/adonisjs/adonis-lucid/issues/366
      */
-    if (!this._isHiddenPivotKey(pivotModel)) {
+    if (!this._isHiddenPivotAttribute(pivotModel)) {
       pivotModel.newUp(pivotAttributes)
       row.setRelated(this.$pivotAttribute, pivotModel)
     }
@@ -367,7 +367,7 @@ class BelongsToMany extends BaseRelation {
    * This method resolve enhancement of "Issue #366":
    * @link https://github.com/adonisjs/adonis-lucid/issues/366
    *
-   * @method  _isHiddenPivotKey
+   * @method  _isHiddenPivotAttribute
    *
    * @param   {Object}  pivotModel
    *
@@ -375,7 +375,7 @@ class BelongsToMany extends BaseRelation {
    *
    * @private
    */
-  _isHiddenPivotKey (pivotModel) {
+  _isHiddenPivotAttribute (pivotModel) {
     /**
      * Get hidden field list.
      *

--- a/test/unit/lucid-belongs-to-many.spec.js
+++ b/test/unit/lucid-belongs-to-many.spec.js
@@ -2961,5 +2961,4 @@ test.group('Relations | Belongs To Many', (group) => {
     const userPosts = user.posts()
     assert.equal(userPosts.$pivotAttribute, 'pivot')
   })
-
 })

--- a/test/unit/lucid-belongs-to-many.spec.js
+++ b/test/unit/lucid-belongs-to-many.spec.js
@@ -2961,4 +2961,26 @@ test.group('Relations | Belongs To Many', (group) => {
     const userPosts = user.posts()
     assert.equal(userPosts.$pivotAttribute, 'pivot')
   })
+
+  test('throw exception when pivotModel is defined and calling pivotPrimaryKey', (assert) => {
+    class Post extends Model {
+    }
+
+    class PostUser extends Model {
+    }
+
+    class User extends Model {
+      posts () {
+        return this.belongsToMany(Post).pivotModel(PostUser).pivotPrimaryKey('key')
+      }
+    }
+
+    User._bootIfNotBooted()
+    Post._bootIfNotBooted()
+    PostUser._bootIfNotBooted()
+
+    const user = new User()
+    const fn = () => user.posts()
+    assert.throw(fn, 'E_INVALID_RELATION_METHOD: Cannot call pivotPrimaryKey since pivotModel has been defined')
+  })
 })

--- a/test/unit/lucid-belongs-to-many.spec.js
+++ b/test/unit/lucid-belongs-to-many.spec.js
@@ -2937,4 +2937,29 @@ test.group('Relations | Belongs To Many', (group) => {
     assert.property(userPosts.toJSON()[0], 'renamed_pivot')
     assert.property(userPosts.toJSON()[1], 'renamed_pivot')
   })
+
+  test('expect pivot attribute name is \'pivot\' when passing true to \'.pivotAttribute()\' in relationship.', (assert) => {
+    class Post extends Model {
+    }
+
+    class PostUser extends Model {
+    }
+
+    class User extends Model {
+      posts () {
+        return this.belongsToMany(Post)
+          .pivotModel(PostUser)
+          .pivotAttribute(true)
+      }
+    }
+
+    User._bootIfNotBooted()
+    Post._bootIfNotBooted()
+    PostUser._bootIfNotBooted()
+
+    const user = new User()
+    const userPosts = user.posts()
+    assert.equal(userPosts.$pivotAttribute, 'pivot')
+  })
+
 })


### PR DESCRIPTION
## Proposed changes

Allow to hide or rename `pivot` attribute from belongsToMany relationships.

### How to use

When you create a relationship `belongsToMany`, you may want to hide the `pivot` attribute that is displayed by default. There are a few ways to do this.

**First way**
> Adding a `$pivot` special field to the list of hidden fields on pivot model.
> See https://adonisjs.com/docs/4.1/lucid#_hiding_fields

```javascript
class PostUser extends Model {
  static get hidden () {
    return ['$pivot']
  }
}
```

**Second way**
> Like `.pivotModel()` and other available methods, you can use a new `.pivotAttribute()` method to rename or hide the `pivot` attribute. If passing `false` is going to hide the field, if passing a` string` will rename it.
> See https://adonisjs.com/docs/4.1/relationships#_belongs_to_many

```javascript
// example 1
class Post extends Model {}

class PostUser extends Model {}

class User extends Model {
  posts () {
    return this.belongsToMany(Post)
        .pivotModel(PostUser)
        .pivotAttribute(false) // hide `pivot` attribute.
  }
}

// example 2
class Post extends Model {}

class PostUser extends Model {}

class User extends Model {
  posts () {
    return this.belongsToMany(Post)
        .pivotModel(PostUser)
        .pivotAttribute('rename_pivot') // rename `pivot` to `rename_pivot` attribute.
  }
}
```

**Third way**
> Similarly to the `static get hidden () {} ` static method, you can use a new static method called `static get pivotAttribute () {}`. If it returns `false` it will hide the` pivot` attribute, returning a `string` will rename the` pivot` attribute.
> See https://adonisjs.com/docs/4.1/lucid#_hiding_fields

```javascript
// example 1
class PostUser extends Model {
  static get pivotAttribute () {
    return false // hide `pivot` attribute.
  }
}

// example 2
class PostUser extends Model {
  static get pivotAttribute () {
    return 'renamed_pivot' // rename `pivot` to `rename_pivot` attribute.
  }
}
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-lucid/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

Related to #366 
